### PR TITLE
Fix dual-band SSID resolution and AiMesh node VLAN support

### DIFF
--- a/functions/hw_probe.sh
+++ b/functions/hw_probe.sh
@@ -64,12 +64,15 @@ RADIOS=""
 GUEST_SLOTS=0
 MAX_SSIDS=0
 
+# AiMesh nodes remap wl interfaces to ethX; bypass /sys/class/net check for them
+is_node=$(nvram get re_mode 2>/dev/null)
+
 # Iterate through radio indices 0, 1, 2 (potential radio slots on Merlin)
 for radio in 0 1 2; do
     # Retrieve interface name from nvram (e.g., wl0_ifname, wl1_ifname, wl2_ifname)
     ifname=$(nvram get "wl${radio}_ifname" 2>/dev/null)
-    # Verify interface exists in kernel
-    if [ -n "$ifname" ] && [ -d "/sys/class/net/$ifname" ]; then
+    # Verify interface exists in kernel (or bypass check for AiMesh nodes)
+    if [ -n "$ifname" ] && { [ "$is_node" = "1" ] || [ -d "/sys/class/net/$ifname" ]; }; then
         # Map radio index to band name
         case $radio in
             0) band="2.4" ;;      # 2.4 GHz band

--- a/functions/mervlan_manager.sh
+++ b/functions/mervlan_manager.sh
@@ -893,6 +893,8 @@ find_if_by_ssid_any() {
   [ "$TARGET_NORM" = "unused-placeholder" ] && return 1
   TARGET_LOWER=$(to_lower "$TARGET_NORM")
 
+  EXACT_MATCHES=""
+  EXACT_COUNT=0
   FALLBACK_IFACE=""
   FALLBACK_LABELS=""
   FALLBACK_COUNT=0
@@ -920,11 +922,11 @@ find_if_by_ssid_any() {
         ssid_norm=$(normalize_ssid "$raw")
 
         if [ "$ssid_norm" = "$TARGET_NORM" ]; then
-          echo "$iface"
-          return 0
-        fi
-
-        if [ -n "$ssid_norm" ] && [ "$(to_lower "$ssid_norm")" = "$TARGET_LOWER" ]; then
+          # Collect exact match (don't return early — there may be more bands)
+          EXACT_MATCHES="${EXACT_MATCHES}${EXACT_MATCHES:+
+}${iface}"
+          EXACT_COUNT=$((EXACT_COUNT + 1))
+        elif [ -n "$ssid_norm" ] && [ "$(to_lower "$ssid_norm")" = "$TARGET_LOWER" ]; then
           if [ "$FALLBACK_COUNT" -eq 0 ]; then
             FALLBACK_IFACE="$iface"
             FALLBACK_LABELS="$ssid_norm -> $iface"
@@ -938,6 +940,12 @@ find_if_by_ssid_any() {
   done <<EOF
 $(nvram show 2>/dev/null | grep -E '^wl[0-9](\.[0-9]+)?_ssid=')
 EOF
+
+  # Return all exact matches (one per line) if any were found
+  if [ "$EXACT_COUNT" -ge 1 ]; then
+    printf '%s\n' "$EXACT_MATCHES"
+    return 0
+  fi
 
   if [ "$FALLBACK_COUNT" -eq 1 ]; then
     warn -c cli,vlan "Case-insensitive match for '$TARGET_NORM' -> $FALLBACK_IFACE"
@@ -1178,17 +1186,20 @@ bind_configured_ssids() {
 
     if [ "$ssid" != "unused-placeholder" ]; then
       validate_vlan_id "$vlan" || { i=$((i+1)); continue; }
-      # Find interface for this SSID (searches all bands/slots)
+      # Find ALL interfaces for this SSID (handles dual-band identical SSIDs)
       IFN="$(find_if_by_ssid_any "$ssid")"
       if [ -n "$IFN" ]; then
-        info -c cli,vlan "Resolved SSID '$ssid' -> $IFN"
-        if ! wait_for_interface "$IFN"; then
-          warn -c cli,vlan "$IFN did not appear within timeout"
-          i=$((i+1))
-          continue
-        fi
-        # Attach to appropriate bridge (br0, brVID, or trunk)
-        attach_to_bridge "$IFN" "$vlan" "SSID_$(printf "%02d" $i)"
+        while IFS= read -r _ifn; do
+          [ -n "$_ifn" ] || continue
+          info -c cli,vlan "Resolved SSID '$ssid' -> $_ifn"
+          if ! wait_for_interface "$_ifn"; then
+            warn -c cli,vlan "$_ifn did not appear within timeout"
+            continue
+          fi
+          attach_to_bridge "$_ifn" "$vlan" "SSID_$(printf "%02d" $i)"
+        done <<_SSID_EOF_
+$IFN
+_SSID_EOF_
       else
         warn -c cli,vlan "SSID_$(printf "%02d" $i) '$ssid' not found on any band"
       fi
@@ -1251,7 +1262,12 @@ resolve_and_attach() {
     return
   fi
 
-  attach_to_bridge "$IFN" "$VLAN" "$LABEL ($SSID)"
+  while IFS= read -r _ifn; do
+    [ -n "$_ifn" ] || continue
+    attach_to_bridge "$_ifn" "$VLAN" "$LABEL ($SSID)"
+  done <<_RAA_EOF_
+$IFN
+_RAA_EOF_
 }
 
 # --------------------------
@@ -1639,9 +1655,12 @@ main() {
     apiso=$(get_apiso_slot_value "$i" "$SETTINGS_FILE")
     # Apply AP isolation if SSID is configured and APISO value is set
     if [ -n "$ssid" ] && [ "$ssid" != "unused-placeholder" ] && [ -n "$apiso" ]; then
-      iface=$(find_if_by_ssid_any "$ssid")
-      if [ -n "$iface" ]; then
-        set_ap_isolation "$iface" "$apiso"
+      _apiso_iflist=$(find_if_by_ssid_any "$ssid")
+      if [ -n "$_apiso_iflist" ]; then
+        printf '%s\n' "$_apiso_iflist" | while IFS= read -r _apiso_ifn; do
+          [ -n "$_apiso_ifn" ] || continue
+          set_ap_isolation "$_apiso_ifn" "$apiso"
+        done
       fi
     fi
     i=$((i+1))

--- a/functions/sync_nodes.sh
+++ b/functions/sync_nodes.sh
@@ -109,6 +109,7 @@ functions/collect_local_clients.sh
 functions/heal_event.sh  
 functions/service-event-handler.sh
 functions/hw_probe.sh
+functions/mervlan_trunk.sh
 templates/mervlan_templates.sh
 "
 
@@ -121,6 +122,7 @@ functions/collect_local_clients.sh
 functions/heal_event.sh
 functions/service-event-handler.sh
 functions/hw_probe.sh
+functions/mervlan_trunk.sh
 "
 # FILES_TO_COPY_CHMOD_644 — Config scripts that should remain non-executable
 FILES_TO_COPY_CHMOD_644="
@@ -461,17 +463,36 @@ copy_file_to_node() {
         return 0
     fi
 
-    # Special handling for settings.json: reset Trunks section to prevent trunk configs on nodes
+    # Special handling for settings.json: inject node-aware trunk config
+    # Nodes need TRUNK1 enabled so the backhaul port carries tagged VLAN traffic.
     if [ "$file" = "settings/settings.json" ]; then
         _cfn_tmp="$TMPDIR/settings_trunk_reset_sync_node${node_id}.$$"
         cp "$MERV_BASE/$file" "$_cfn_tmp" 2>/dev/null || {
-            error -c cli,vlan "✗ Failed to create temp file for trunk reset"
+            error -c cli,vlan "✗ Failed to create temp file for trunk config"
             rm -f "$_cfn_tmp" 2>/dev/null
             return 1
         }
 
-        # Reset Trunks section to defaults (nodes should never trunk)
-        if ! json_reset_trunks_section "$_cfn_tmp"; then
+        # Zero all trunks first (clean slate), then inject node trunk config
+        if json_reset_trunks_section "$_cfn_tmp"; then
+            # Collect all VLAN IDs from the SSID pool
+            _cfn_vlan_list=""
+            _cfn_vi=1
+            while [ "$_cfn_vi" -le 12 ]; do
+                _cfn_vid="$(json_get_flag "VLAN_$(printf '%02d' "$_cfn_vi")" "" "$_cfn_tmp")"
+                case "$_cfn_vid" in
+                    ""|none|*[!0-9]*) ;;
+                    *) _cfn_vlan_list="${_cfn_vlan_list}${_cfn_vlan_list:+,}${_cfn_vid}" ;;
+                esac
+                _cfn_vi=$((_cfn_vi + 1))
+            done
+            # Enable TRUNK1 for node backhaul with collected VLANs
+            if [ -n "$_cfn_vlan_list" ]; then
+                json_set_flag "TRUNK1" "1" "$_cfn_tmp"
+                json_set_flag "TAGGED_TRUNK1" "$_cfn_vlan_list" "$_cfn_tmp"
+                info -c cli,vlan "Node trunk config: TRUNK1=1, TAGGED=$_cfn_vlan_list"
+            fi
+        else
             warn -c cli,vlan "⚠️ Failed to reset trunks section, copying original file"
             rm -f "$_cfn_tmp" 2>/dev/null
             # Fallback to original file


### PR DESCRIPTION
### Overview
Two bugs prevent guest network VLANs from working on AiMesh nodes:

**Dual-band SSID resolution**: When a guest network uses the same SSID on both bands, mervlan_manager.sh only bridges the first matching interface, leaving the second band unsecured.

**AiMesh node radio detection**: On AiMesh nodes, wireless interfaces are temporarily remapped to Ethernet names during boot. The hardware checks in hw_probe.sh fail to find them, resulting in 0 detected SSIDs. This causes lib_ssid_filter.sh to disable all guest networks and prevents sync_nodes.sh from injecting the necessary trunk configuration for the backhaul port.

### Changes

**mervlan_manager.sh** : Updated SSID resolution to return all matching interfaces (fixing dual-band guest networks) and modified callers to handle multiple results.

**hw_probe.sh** : Bypassed interface checks for AiMesh nodes, allowing correct radio/SSID detection during backhaul setup.

**sync_nodes.sh** : Added trunk configuration injection during node sync so the backhaul port properly carries tagged VLAN traffic.

### Testing
Verified its working on ZenWiFi XT8 (RT-AX95Q) AiMesh setup with 1 main AP + 1 node, Ethernet backhaul:

Main AP: brctl show confirms both wl0.1 and wl1.1 attached to br20
Node: brctl show confirms wl0.2, wl1.2, eth0.20, and eth1.20 attached to br20