### PR TITLE
fix: prevent boot shield from retaining DHCP hold

### DIFF
--- a/functions/mervlan_boot_wrap.sh
+++ b/functions/mervlan_boot_wrap.sh
@@ -139,8 +139,10 @@ _mode_shield() {
   fi
 
   # Step 1: arm the DHCP hold up-front so the window is closed before the
-  # watchdog even forks. quiet mode suppresses the per-tick log noise.
-  merv_dhcp_hold_arm quiet
+  # watchdog even forks.  The boot shield owns a separate marker, so it must
+  # not create merv_dhcp_hold.active here: otherwise a final watchdog tick can
+  # recreate that shared manager/heal marker after the manager releases it.
+  merv_dhcp_hold_arm quiet no-marker
   info -c boot,vlan "Shield: MERV_DHCP_HOLD armed (boot critical section)"
 
   # Step 2: replay the persistent MERV_MAC snapshot if we have one. Best-effort;
@@ -182,9 +184,9 @@ _mode_shield() {
       fi
 
       # Re-arm DHCP hold against any rc-driven ebtables flush during the boot
-      # storm. Idempotent — fast-paths to a no-op when the chain + jumps are
-      # already in place.
-      merv_dhcp_hold_arm quiet 2>/dev/null || true
+      # storm. Keep ownership on the boot marker only. A manager/heal caller
+      # that needs a durable hold writes merv_dhcp_hold.active itself.
+      merv_dhcp_hold_arm quiet no-marker 2>/dev/null || true
 
       sleep 1
       _now=$(date +%s 2>/dev/null || echo 0)

--- a/settings/lib_mervqt.sh
+++ b/settings/lib_mervqt.sh
@@ -486,10 +486,17 @@ restore_merv_qt_shield() {
 # section. A .active marker under $LOCKDIR lets any tick re-arm idempotently.
 # ============================================================================
 
-# merv_dhcp_hold_arm [quiet]
+# merv_dhcp_hold_arm [quiet] [no-marker]
+#
+# The hold marker records ownership by manager/heal callers so their guard
+# ticks can restore the rule if firmware flushes ebtables mid-operation.  The
+# boot shield is deliberately not an owner: it has its own
+# merv_boot_shield.active marker and must not recreate the shared ownership
+# marker after the manager has released it.
 merv_dhcp_hold_arm() {
-  local _hold_rules _changed _quiet
+  local _hold_rules _changed _quiet _marker_mode
   _quiet="${1:-0}"
+  _marker_mode="${2:-marker}"
   _changed=0
 
   type ebtables >/dev/null 2>&1 || return 0
@@ -512,7 +519,8 @@ merv_dhcp_hold_arm() {
     _changed=1
   fi
 
-  echo "$(date +%s)" > "$LOCKDIR/merv_dhcp_hold.active" 2>/dev/null || true
+  [ "$_marker_mode" = "no-marker" ] || \
+    echo "$(date +%s)" > "$LOCKDIR/merv_dhcp_hold.active" 2>/dev/null || true
   [ "$_changed" -eq 1 ] && [ "$_quiet" != "quiet" ] && \
     info -c vlan "DHCP hold: armed for br0 critical section"
 }


### PR DESCRIPTION
I have just finished hours of debugging for this one dang issue 😂😅

DHCP mysteriously broke only on this one AP and it was PAINFUL to figure out. I was almost to the point of blaming the UPS I had plugged into the AP :/

So once I found the rule blocking DHCP, I had Codex 5.6 Terra make this PR, and here is what it said:

----

Before the change, MerVLAN used one shared “DHCP hold is active” file for two different purposes:

- The boot watchdog used it while the AP was starting.
- The VLAN manager/healer used it while it was actively changing network configuration.

That’s the problem. At boot, the manager finishes and removes the DHCP-block rule. But the boot watchdog can wake up a moment later and recreate both the block and that shared file. Then it sees the file and concludes, “someone else must still need DHCP blocked,” so it leaves the block forever.

The patch gives the boot watchdog a different behavior:

- It still installs the DHCP block during the brief unsafe boot window.
- It still re-adds that block if ASUS flushes bridge rules during startup.
- But it **does not create the shared “manager/healer owns DHCP blocking” marker**.
- When startup finishes, it can remove its own temporary block cleanly.
- If the actual VLAN manager or repair process needs DHCP blocked, those processes still create the shared marker exactly as before.

I installed this manually on my XT8 APs and tested it, and it works perfectly.